### PR TITLE
Fix functional group detection logic using `any()` for hydrogen bond donor/acceptor

### DIFF
--- a/src/(6)gen_FG_KG.py
+++ b/src/(6)gen_FG_KG.py
@@ -23,20 +23,20 @@ def solubility_cal(mol):
     return solubility
 
 # Define functional groups for hydrogen bond donors and acceptors
-hydrogen_bond_donor = [
+HYDROGEN_BOND_DONOR = {
     'hydroxyl', 'hydroperoxy', 'primary_amine', 'secondary_amine', 
     'hydrazone', 'primary_ketimine', 'secondary_ketimine', 'primary_aldimine',
     'amide', 'sulfhydryl', 'sulfonic_acid', 'thiolester', 'hemiacetal', 
     'hemiketal', 'carboxyl', 'aldoxime', 'ketoxime'
-]
+}
 
-hydrogen_bond_acceptor = [
+HYDROGEN_BOND_ACCEPTOR = {
     'ether', 'peroxy', 'haloformyl', 'ketone', 'aldehyde', 'carboxylate', 
     'carboxyl', 'ester', 'ketal', 'carbonate_ester', 'carboxylic_anhydride',
     'primary_amine', 'secondary_amine', 'tertiary_amine', '4_ammonium_ion', 
     'hydrazone', 'primary_ketimine', 'secondary_ketimine', 'primary_aldimine', 
     'amide', 'sulfhydryl', 'sulfonic_acid', 'thiolester', 'aldoxime', 'ketoxime'
-]
+}
 
 # Generate node features for each molecule based on SMILES string
 def gen_node_feature(sm):
@@ -66,9 +66,9 @@ def gen_node_feature(sm):
         if prop != '':
             functional_group.add(prop)
     
-    if functional_group in hydrogen_bond_donor:
+    if any(fg in HYDROGEN_BOND_DONOR for fg in functional_group):
         is_hydrogen_bond_donor = 1
-    if functional_group in hydrogen_bond_acceptor:
+    if any(fg in HYDROGEN_BOND_ACCEPTOR for fg in functional_group):
         is_hydrogen_bond_acceptor = 1
 
     for bond in mol.GetBonds():

--- a/src/(7)train_FG_KGE.py
+++ b/src/(7)train_FG_KGE.py
@@ -230,4 +230,4 @@ if __name__ == "__main__":
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     feature_dict = train(args.FGKG_path, args.checkpoint, device, args.epochs, args.embedding_dim, args.lr, args.batch_size)
     with open(args.feature_dict_path, 'wb') as f:
-        pickle.dump(feature_dict)
+        pickle.dump(feature_dict, f)

--- a/src/(8)gen_FG_molecular_graph.py
+++ b/src/(8)gen_FG_molecular_graph.py
@@ -55,7 +55,7 @@ def graph_data(smiles, feature_dict):
     
     # Assign atom features to the feature matrix
     for idx, value in new_structure.items():
-        atom_features[idx, :] = value['fg_feature']
+        atom_features[idx, :] = value['fg_feature'].detach().numpy()
 
     # Initialize edge index matrix
     edge_index = torch.zeros((2, num_edges), dtype=torch.long)


### PR DESCRIPTION

### 📌 Summary
This PR fixes a bug in the `gen_node_feature()` function where functional groups were incorrectly checked for membership in the predefined hydrogen bond donor and acceptor lists.


### 🐛 Problem
Previously, the following code was used to determine whether a molecule contained any hydrogen bond donor or acceptor:

```python
if functional_group in hydrogen_bond_donor:
    is_hydrogen_bond_donor = 1
```

This expression always returns `False`, even if individual elements of `functional_group` are in the donor list, because it's trying to check if a **set** exists **as a single item** in a list — which is not valid for element-wise comparison.



### ✅ Fix
Replaced the faulty logic with the correct use of the built-in `any()` function:

```python
if any(fg in hydrogen_bond_donor for fg in functional_group):
    is_hydrogen_bond_donor = 1
```

This properly checks whether **any** of the individual functional groups in the set appear in the hydrogen bond donor (or acceptor) list.
